### PR TITLE
Fix and expose only-comment-on-change input

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ jobs:
           # Your organization's DevCycle API client ID & secret
           client-id: ${{ secrets.DVC_CLIENT_ID }}
           client-secret: ${{ secrets.DVC_CLIENT_SECRET }}
-
+          # Only add a comment to the PR if there are changes to DevCycle variables
+          only-comment-on-change: true
 ```
 
 We recommend including your DevCycle API credentials and project token as inputs.

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -32,6 +32,7 @@ describe('run', () => {
             },
         }
         core.getInput = jest.fn().mockImplementation((key) => mockInputs[key])
+        core.getBooleanInput = jest.fn().mockReturnValue(false)
         octokit.rest = {
             issues: {
                 listComments: jest.fn(),
@@ -196,11 +197,7 @@ describe('run', () => {
     )
 
     it('PR comment is not created if no changes exist and only-comment-on-change is true', async () => {
-        const inputs: Record<string, string | boolean> = {
-            ...mockInputs,
-            'only-comment-on-change': true,
-        }
-        core.getInput = jest.fn().mockImplementation((key) => inputs[key])
+        core.getBooleanInput.mockReturnValue(true)
 
         const cliOutput = '\nNo DevCycle Variables Changed\n'
         exec.getExecOutput = jest.fn().mockResolvedValue({ stdout: cliOutput })
@@ -217,11 +214,7 @@ describe('run', () => {
     })
 
     it('PR comment is removed if no changes exist and only-comment-on-change is true', async () => {
-        const inputs: Record<string, string | boolean> = {
-            ...mockInputs,
-            'only-comment-on-change': true,
-        }
-        core.getInput = jest.fn().mockImplementation((key) => inputs[key])
+        core.getBooleanInput.mockReturnValue(true)
 
         const cliOutput = '\nNo DevCycle Variables Changed\n'
         exec.getExecOutput = jest.fn().mockResolvedValue({ stdout: cliOutput })

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   color: blue
   icon: flag
 inputs:
+  github-token:
+    description: "The GitHub token for your repo"
+    required: true
   project-key:
     description: "Your DevCycle project key (Recommended)"
     required: false
@@ -14,9 +17,9 @@ inputs:
   client-secret:
     description: "Your DevCycle API client secret (Recommended)"
     required: false
-  github-token:
-    description: "The GitHub token for your repo"
-    required: true
+  only-comment-on-change:
+    description: "If true, comments will only be added to PRs when changes to DevCycle variables are detected. Defaults to false."
+    required: false
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,7 +62,7 @@ function run() {
         const projectKey = core.getInput('project-key');
         const clientId = core.getInput('client-id');
         const clientSecret = core.getInput('client-secret');
-        const onlyCommentOnChange = core.getInput('only-comment-on-change');
+        const onlyCommentOnChange = core.getBooleanInput('only-comment-on-change');
         const octokit = token && github.getOctokit(token);
         if (!token) {
             core.setFailed('Missing github token');

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,7 @@ export async function run() {
     const projectKey = core.getInput('project-key')
     const clientId = core.getInput('client-id')
     const clientSecret = core.getInput('client-secret')
-    const onlyCommentOnChange = core.getInput('only-comment-on-change')
+    const onlyCommentOnChange = core.getBooleanInput('only-comment-on-change')
     const octokit = token && github.getOctokit(token)
 
     if (!token) {


### PR DESCRIPTION
I initially noticed that when using the Github Action extension, the `only-comment-on-change` input was not properly exposed from the action and decided to fix it. _I also took the liberty to move`github-token` to the top of the list_

<img width="749" height="30" alt="image" src="https://github.com/user-attachments/assets/f8fcf19e-8f2c-415e-8c5d-d701968c2222" />

> [!WARNING]
> Seems like job logs also warn about this
`Warning: Unexpected input(s) 'only-comment-on-change', valid inputs are ['project-key', 'client-id', 'client-secret', 'github-token']` 

During which I discovered the current parsing of the input was for string based values therefore setting `only-comment-on-change` to any string would always be truthy [here](https://github.com/DevCycleHQ/feature-flag-pr-insights-action/blob/main/src/action.ts#L14) and [here](https://github.com/DevCycleHQ/feature-flag-pr-insights-action/blob/main/src/action.ts#L82)

The quick fix is then to ensure the input actually matches a truthy value by using `getBooleanInput`