### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 
 name: Unit Tests
+permissions:
+  contents: read
 
 on:
   pull_request


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/4](https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow file to limit the GITHUB_TOKEN permissions. The best way is to set a top-level `permissions` key, ensuring all jobs default to minimal required privileges. In this case, specifying `contents: read` at the workflow root will suffice, as neither the license-check nor the run-tests job appears to require write access. 

No changes to the existing job steps or logic are needed. Add the following block near the top of the workflow file (after `name:` and before `on:`), as per GitHub Actions conventions:

```yaml
permissions:
  contents: read
```

This will restrict the GITHUB_TOKEN used by all jobs to read-only access to repo contents and follow best practices for GitHub workflow security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
