### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
           language: "javascript"
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/3](https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/3)

To fix the issue, we should explicitly specify a `permissions` block for the `run-tests` job, ensuring that it only has the minimum required permissions. Since `run-tests` merely checks out code, sets up Node, installs dependencies, and runs tests, it can safely be restricted to `contents: read`. This can be done by adding a `permissions:` entry below `runs-on: ubuntu-latest` in the `run-tests` job definition (i.e., after line 17). No changes to existing functionality or further permissions are needed.

If desired, you could also apply the `permissions:` block at the workflow root (above `jobs:`) to affect all jobs that do not specify their own permissions, but for the purpose of addressing the explicit flagged area (the `run-tests` job), a per-job block is clearest.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
