### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,6 @@
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   dvc-variable-diff:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/2](https://github.com/DevCycleHQ/feature-flag-pr-insights-action/security/code-scanning/2)

To fix the problem, add a `permissions: contents: read` block either to the workflow root (affecting all jobs) or specifically to the `dvc-variable-diff` job (only that job). As only one job is present, the root or job-level placement has equivalent effect. This minimally restricts the token to read-only permissions on repository contents, adhering to the principle of least privilege and mitigating unnecessary write access in the workflow.

**Steps:**
- Edit `.github/workflows/workflow.yml`.
- Insert a `permissions:` block with `contents: read` at the top level, after the workflow name (if present) and before or after `on`, *or* within the job definition.  
- No external modules or changes to other workflow logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
