### PR TITLE
chore: add release workflow and update yarn to 4.13.0

### DIFF
--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version-file: '.nvmrc'
             - name: Setup Yarn
               run: |
                   corepack enable

--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -31,6 +31,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -1,0 +1,85 @@
+name: 'Release and Build'
+on:
+    workflow_dispatch:
+        inputs:
+            prerelease:
+                description: 'Prerelease'
+                required: true
+                default: false
+                type: boolean
+            draft:
+                description: 'Draft'
+                required: true
+                default: false
+                type: boolean
+            version-increment-type:
+                description: 'Which part of the version to increment:'
+                required: true
+                type: choice
+                options:
+                    - major
+                    - minor
+                    - patch
+                default: 'patch'
+permissions:
+    contents: write
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: '20'
+            - name: Setup Yarn
+              run: |
+                  corepack enable
+                  corepack prepare yarn@4.13.0 --activate
+            - name: Install dependencies
+              shell: bash
+              run: yarn install
+
+            - name: Build project
+              shell: bash
+              run: yarn build
+            - name: Prepare Release
+              id: prepare_release
+              uses: DevCycleHQ/release-action/prepare-release@v2.3.0
+              with:
+                  github-token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+                  version-increment-type: ${{ github.event.inputs.version-increment-type || 'patch' }}
+                  prerelease: ${{ github.event.inputs.prerelease }}
+                  draft: ${{ github.event.inputs.draft }}
+            - name: Update README.md
+              run: |
+                  sed -i -E 's/(DevCycleHQ\/feature-flag-pr-insights-action@)(main|v[0-9]+\.[0-9]+\.[0-9]+)/\1v${{steps.prepare_release.outputs.next-release-tag}}/g' README.md
+              if: github.event.inputs.draft != true
+
+            - name: Commit version change and README update
+              run: |
+                  git config --global user.email "foundation-admin@devcycle.com"
+                  git config --global user.name "DevCycle Automation"
+                  git add .
+                  git commit -m "Release ${{steps.prepare_release.outputs.next-release-tag}} and update README"
+              if: github.event.inputs.draft != true
+
+            - name: Push version change
+              run: |
+                  git pull
+                  git push -u origin main
+              if: github.event.inputs.draft != true
+            - name: Create Release
+              id: create_release
+              uses: DevCycleHQ/release-action/create-release@v2.3.0
+              with:
+                  tag: ${{ steps.prepare_release.outputs.next-release-tag }}
+                  target: ${{ github.sha }}
+                  changelog: ${{ steps.prepare_release.outputs.changelog }}
+                  github-token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+                  prerelease: ${{ github.event.inputs.draft }}
+                  draft: ${{ github.event.inputs.draft }}

--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -33,7 +33,7 @@ jobs:
                   token: ${{ secrets.AUTOMATION_USER_TOKEN }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: '20'
             - name: Setup Yarn
@@ -69,17 +69,19 @@ jobs:
               if: github.event.inputs.draft != true
 
             - name: Push version change
+              id: push_version
               run: |
-                  git pull
+                  git pull --ff-only
                   git push -u origin main
+                  echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
               if: github.event.inputs.draft != true
             - name: Create Release
               id: create_release
               uses: DevCycleHQ/release-action/create-release@v2.3.0
               with:
                   tag: ${{ steps.prepare_release.outputs.next-release-tag }}
-                  target: ${{ github.sha }}
+                  target: ${{ steps.push_version.outputs.sha || github.sha }}
                   changelog: ${{ steps.prepare_release.outputs.changelog }}
                   github-token: ${{ secrets.AUTOMATION_USER_TOKEN }}
-                  prerelease: ${{ github.event.inputs.draft }}
+                  prerelease: ${{ github.event.inputs.prerelease }}
                   draft: ${{ github.event.inputs.draft }}

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
         "minimatch@^9.0.4": "^9.0.7",
         "tar@^7.4.3": "^7.5.11"
     },
-    "packageManager": "yarn@4.9.1"
+    "packageManager": "yarn@4.13.0"
 }


### PR DESCRIPTION
## Summary

- Add `release-and-build.yml` workflow (copied from `feature-flag-code-usage-action`) to enable automated releases via `workflow_dispatch`
- Update Yarn from 4.9.1 to 4.13.0

## Motivation

This repo had no release workflow — releases were done entirely manually (create tag, create GH release, update README). The sibling `feature-flag-code-usage-action` repo already has a `release-and-build.yml` workflow using `DevCycleHQ/release-action`, so this copies that process over.

The workflow:
1. Builds the project
2. Bumps the version via `DevCycleHQ/release-action/prepare-release`
3. Updates the README version reference
4. Commits and pushes to `main`
5. Creates a GitHub Release with changelog

Triggered manually from the Actions tab with `major`/`minor`/`patch` selection.

### Notes

- Requires the `AUTOMATION_USER_TOKEN` secret (should already be available as an org-level secret)