### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -28,13 +28,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   token: ${{ secrets.AUTOMATION_USER_TOKEN }}
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version-file: '.nvmrc'
             - name: Setup Yarn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: DevCycleHQ/license-action@main
         with:
           language: "javascript"
@@ -20,8 +20,8 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
     - run: corepack enable && yarn --version
     - run: yarn install
     - run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
     - run: corepack enable && yarn --version
     - run: yarn install
     - run: yarn test

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -10,13 +10,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   token: ${{ secrets.AUTOMATION_USER_TOKEN }}
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version-file: '.nvmrc'
             - name: Setup Yarn

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Fetch DevCycle variable diff
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.